### PR TITLE
Check for non-default scoop app directory path on Windows

### DIFF
--- a/scripts/xornet-reporter.json
+++ b/scripts/xornet-reporter.json
@@ -27,7 +27,8 @@
   "post_install": [
     "$token = Read-Host -Prompt 'Please enter your signup token: '",
     "$curPath = Get-Location",
-    "cd ~/scoop/apps/xornet-reporter/0.16.4",
+    "if ($null -ne $env:SCOOP) { $scoopRoot = $env:SCOOP } else { $scoopRoot = '~/scoop' }",
+    "cd $scoopRoot/apps/xornet-reporter/0.16.4",
     "$xornetPath = Get-Location",
     "sudo nssm install 'Xornet Reporter' $xornetPath/xornet-reporter.exe \"--silent\"",
     "xornet-reporter.exe -su $token",


### PR DESCRIPTION
When installing the runner on Windows the package failed to install because it assumed that my scoop apps directory was at `~/scoop/apps`, which it was not. I had moved it where I had more storage for it.

Per information here: https://github.com/ScoopInstaller/Scoop
Users can move the scoop apps directory to a different location by setting the `SCOOP` environment variable before the installation. The variable is set for the life of the scoop installation.

I tweaked the json to check for the presence of this variable. If it is not present, it assumes the default behavior.