### PR TITLE
Use perfmon for improved data capture of CPU frequency on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,16 +1960,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c47017195a790490df51a3e27f669a7d4f285920d90d03ef970c5d886ef0af1"
+dependencies = [
+ "windows_aarch64_msvc 0.38.0",
+ "windows_i686_gnu 0.38.0",
+ "windows_i686_msvc 0.38.0",
+ "windows_x86_64_gnu 0.38.0",
+ "windows_x86_64_msvc 0.38.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.34.0",
+ "windows_i686_gnu 0.34.0",
+ "windows_i686_msvc 0.34.0",
+ "windows_x86_64_gnu 0.34.0",
+ "windows_x86_64_msvc 0.34.0",
 ]
 
 [[package]]
@@ -1979,10 +1992,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12add87e2fb192fff3f4f7e4342b3694785d79f3a64e2c20d5ceb5ccbcfc3cd"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c98f2db372c23965c5e0f43896a8f0316dc0fbe48d1aa65bea9bdd295d43c15"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1991,16 +2016,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf0569be0f2863ab6a12a6ba841fcfa7d107cbc7545a3ebd57685330db0a3ff"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "905858262c8380a36f32cb8c1990d7e7c3b7a8170e58ed9a98ca6d940b7ea9f1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "890c3c6341d441ffb38f705f47196e3665dc6dd79f6d72fa185d937326730561"
 
 [[package]]
 name = "winreg"
@@ -2051,4 +2094,5 @@ dependencies = [
  "tokio",
  "uuid",
  "websocket",
+ "windows",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,9 +647,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.124"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libloading"
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "xornet-reporter"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,15 @@ colored = "2.0.0"
 
 [target.'cfg(unix)'.build-dependencies]
 openssl = { version = "0.10.38", features = ["vendored"] }
+
+# For data collection that supercedes sysinfo crate functions on Windows
+[dependencies.windows]
+version = "0.38.0"
+features = [
+    "alloc",
+    "Data_Xml_Dom",
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,5 @@ features = [
     "Win32_Security",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_System_Performance"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xornet-reporter"
-version = "0.17.1"
+version = "0.17.2"
 edition = "2018"
 
 # Optimize for size
@@ -35,7 +35,7 @@ colored = "2.0.0"
 openssl = { version = "0.10.38", features = ["vendored"] }
 
 # For data collection that supercedes sysinfo crate functions on Windows
-[dependencies.windows]
+[target.'cfg(windows)'.dependencies.windows]
 version = "0.38.0"
 features = [
     "alloc",

--- a/src/data_collector/cpu.rs
+++ b/src/data_collector/cpu.rs
@@ -236,10 +236,13 @@ impl DataCollector {
         while i < proc_freq_cnt as isize {
             let sz_name_cstr: &CStr = CStr::from_ptr(
                 (*ptr_freq_data_target.offset(i)).szName.0 as *const i8);
-            let str_slice: &str = sz_name_cstr.to_str().unwrap();
+            let str_slice: &str = sz_name_cstr.to_str().unwrap_or("oh shit");
             if str_slice.contains("Total") {
                 i = i + 1;
                 continue;
+            } else if str_slice.contains("oh shit") {
+                eprintln!("Inconsistent data received from perfmon. Aborting.");
+                exit(1);
             }
 
             usage.push(f64::floor(

--- a/src/data_collector/cpu.rs
+++ b/src/data_collector/cpu.rs
@@ -1,3 +1,6 @@
+use std::ffi::CStr;
+use std::mem;
+use std::process::exit;
 #[cfg(target_family = "unix")]
 use sysinfo::{ProcessorExt, SystemExt};
 
@@ -5,7 +8,12 @@ use crate::types::CPUStats;
 
 use anyhow::Result;
 
+#[cfg(target_family = "windows")]
+use windows::Win32::System::Performance::*;
 
+#[cfg(target_family = "windows")]
+use std::ptr;
+use windows::Win32::Foundation::ERROR_SUCCESS;
 
 use super::DataCollector;
 
@@ -31,8 +39,211 @@ impl DataCollector {
 impl DataCollector {
   pub fn get_cpu(&mut self) -> Result<CPUStats> {
     let (mut usage, mut freq) = (vec![], vec![]);
-    // TODO: Implement use of perfmon querying.
-    //       We need to figure out where to store perfmon structures.
+
+    // Stores information about the capacity of the buffer needed for retrieving
+    // counter data from PDH counter methods.
+    let mut proc_freq_sz: u32 = 0;
+    let mut proc_freq_cnt: u32 = 0;
+    let mut proc_perf_sz: u32 = 0;
+    let mut proc_perf_cnt: u32 = 0;
+    let mut proc_util_sz: u32 = 0;
+    let mut proc_util_cnt: u32 = 0;
+
+    // Pointers we need to pass to the aforementioned PDH library methods so that
+    // it can update the values stored here for us to allocate the buffers right.
+    let ptr_freq_sz: *mut u32 = &mut proc_freq_sz;
+    let ptr_freq_cnt: *mut u32 = &mut proc_freq_cnt;
+    let ptr_perf_sz: *mut u32 = &mut proc_perf_sz;
+    let ptr_perf_cnt: *mut u32 = &mut proc_perf_cnt;
+    let ptr_util_sz: *mut u32 = &mut proc_util_sz;
+    let ptr_util_cnt: *mut u32 = &mut proc_util_cnt;
+
+    // Our target for retrieving frequency and usage data. This can either be the
+    // data we retrieved during this method invocation or reusing cached data due to
+    // counter data rolling over during that particular fetch.
+    let ptr_freq_data_target: *mut PDH_FMT_COUNTERVALUE_ITEM_A;
+    let ptr_perf_data_target: *mut PDH_FMT_COUNTERVALUE_ITEM_A;
+    let ptr_util_data_target: *mut PDH_FMT_COUNTERVALUE_ITEM_A;
+
+    unsafe {
+      // Confirm all counters are ready to provide data first as well as
+      // the number of items being returned and the size of the buffer the
+      // PDH library wants from us.
+      let ret = PdhGetFormattedCounterArrayA(self.pdh_proc_freq_counter,
+                                             PDH_FMT_DOUBLE,
+                                             ptr_freq_sz,
+                                             ptr_freq_cnt,
+                                             ptr::null_mut());
+
+      // This return value is given specifically because we pass a null pointer for
+      // the buffer, indicating more room is needed to write. Obviously, absent
+      // an actual buffer, it can't write anything. Any status other than this is
+      // indicative of a problem.
+      if ret != PDH_MORE_DATA {
+        eprintln!("Unable to fetch processor frequency data. Errno: {}", ret);
+        exit(ret);
+      }
+
+      let ret = PdhGetFormattedCounterArrayA(self.pdh_proc_perf_counter,
+                                             PDH_FMT_DOUBLE,
+                                             ptr_perf_sz,
+                                             ptr_perf_cnt,
+                                             ptr::null_mut());
+
+      if ret != PDH_MORE_DATA {
+        eprintln!("Unable to fetch processor performance data. Errno: {}", ret);
+        exit(ret);
+      }
+
+      let ret = PdhGetFormattedCounterArrayA(self.pdh_proc_util_counter,
+                                             PDH_FMT_DOUBLE,
+                                             ptr_util_sz,
+                                             ptr_util_cnt,
+                                             ptr::null_mut());
+
+      if ret != PDH_MORE_DATA {
+        eprintln!("Unable to fetch processor utilization data. Errno: {}", ret);
+        exit(ret);
+      }
+
+      // The windows-rs crate does a little trolling and fails to generate an array of
+      // counter value item structs below whose size match the output the above calls
+      // are given. This could be due to mismatch in how the rust struct implementation
+      // is handled vs what the C struct is like. It could be a byte alignment issue.
+      // We simply do not know.
+      //
+      // However, this method *does* continue to work given some padding to avoid
+      // some padding to avoid buffer overruns. So we add some slush here to capture
+      // this problem and then proceed not to worry about it for the foreseeable future.
+      let mut proc_freq_data: Vec<PDH_FMT_COUNTERVALUE_ITEM_A> =
+          vec!(PDH_FMT_COUNTERVALUE_ITEM_A::default(); (proc_freq_cnt + 2) as usize);
+
+      let mut proc_perf_data: Vec<PDH_FMT_COUNTERVALUE_ITEM_A> =
+          vec!(PDH_FMT_COUNTERVALUE_ITEM_A::default(); (proc_perf_cnt  + 2) as usize);
+
+      let mut proc_util_data: Vec<PDH_FMT_COUNTERVALUE_ITEM_A> =
+          vec!(PDH_FMT_COUNTERVALUE_ITEM_A::default(); (proc_util_cnt + 2) as usize);
+
+      // Now when we invoke these methods again they should always return ERROR_SUCCESS.
+      let ret = PdhGetFormattedCounterArrayA(self.pdh_proc_freq_counter,
+                                   PDH_FMT_DOUBLE,
+                                   ptr_freq_sz,
+                                   ptr_freq_cnt,
+                                   proc_freq_data.as_mut_ptr());
+
+      if ret != ERROR_SUCCESS.0 as i32 {
+          eprintln!("Unable to fetch processor frequency data. Errno: {}", ret);
+          exit(ret);
+      }
+
+
+      PdhGetFormattedCounterArrayA(self.pdh_proc_perf_counter,
+                                   PDH_FMT_DOUBLE,
+                                   ptr_perf_sz,
+                                   ptr_perf_cnt,
+                                   proc_perf_data.as_mut_ptr());
+
+      if ret != ERROR_SUCCESS.0 as i32 {
+          eprintln!("Unable to fetch processor performance data. Errno: {}", ret);
+          exit(ret);
+      }
+
+
+      PdhGetFormattedCounterArrayA(self.pdh_proc_util_counter,
+                                   PDH_FMT_DOUBLE,
+                                   ptr_util_sz,
+                                   ptr_util_cnt,
+                                   proc_util_data.as_mut_ptr());
+
+      if ret != ERROR_SUCCESS.0 as i32 {
+          eprintln!("Unable to fetch processor utilization data. Errno: {}", ret);
+          exit(ret);
+      }
+
+
+      if (proc_freq_cnt == 0 || proc_perf_cnt == 0 || proc_util_cnt == 0) ||
+          ((proc_freq_cnt != proc_perf_cnt) || (proc_freq_cnt != proc_util_cnt)) {
+        // Sometimes one or more counters will roll over (integer overflow) numerically
+        // and so the difference between the most recent counter poll and the previous
+        // one will not pass the sniff test, and the pdh library will flip a tit about it.
+        // In this instance we should just repeat the last data that was valid and then
+        // try again on the next poll. In which case the issue will resolve itself.
+
+        if self.pdh_proc_freq_data_len == 0 {
+            eprintln!("Unable to fetch data from counters and nothing is cached.");
+            exit(1);
+        }
+        ptr_freq_data_target = self.pdh_proc_freq_data_cached;
+        ptr_perf_data_target = self.pdh_proc_perf_data_cached;
+        ptr_util_data_target = self.pdh_proc_util_data_cached;
+      } else {
+
+        // Data received checks out -- continue and replace cached values.
+        ptr_freq_data_target = proc_freq_data.as_mut_ptr();
+        ptr_perf_data_target = proc_perf_data.as_mut_ptr();
+        ptr_util_data_target = proc_util_data.as_mut_ptr();
+
+        // Reassemble cached data as vector so that Rust can deallocate it. Then drop it.
+        // Do not attempt if there is nothing in the cache already.
+        if self.pdh_proc_freq_data_len != 0 {
+            let proc_freq_data_old = Vec::from_raw_parts(self.pdh_proc_freq_data_cached,
+                                                                                      self.pdh_proc_freq_data_len,
+                                                                                             self.pdh_proc_freq_data_capacity);
+            drop(proc_freq_data_old);
+
+
+
+            let proc_perf_data_old = Vec::from_raw_parts(self.pdh_proc_perf_data_cached,
+                                                                                        self.pdh_proc_perf_data_len,
+                                                                                               self.pdh_proc_perf_data_capacity);
+            drop(proc_perf_data_old);
+
+            let proc_util_data_old = Vec::from_raw_parts(self.pdh_proc_util_data_cached,
+                                                                                      self.pdh_proc_util_data_len,
+                                                                                             self.pdh_proc_util_data_capacity);
+            drop(proc_util_data_old);
+        }
+
+        self.pdh_proc_freq_data_cached = proc_freq_data.as_mut_ptr();
+        self.pdh_proc_freq_data_len = proc_freq_data.len();
+        self.pdh_proc_freq_data_capacity = proc_freq_data.capacity();
+
+        self.pdh_proc_perf_data_cached = proc_perf_data.as_mut_ptr();
+        self.pdh_proc_perf_data_len = proc_perf_data.len();
+        self.pdh_proc_perf_data_capacity = proc_perf_data.capacity();
+
+        self.pdh_proc_util_data_cached = proc_util_data.as_mut_ptr();
+        self.pdh_proc_util_data_len = proc_util_data.len();
+        self.pdh_proc_util_data_capacity = proc_util_data.capacity();
+
+        // Prevent Rust from immediately deallocating vec contents at end of method invocation.
+        // Otherwise our cached values will go bye bye.
+        mem::forget(proc_freq_data);
+        mem::forget(proc_perf_data);
+        mem::forget(proc_util_data);
+      }
+
+        let mut i = 0 as isize;
+
+        while i < proc_freq_cnt as isize {
+            let sz_name_cstr: &CStr = CStr::from_ptr(
+                (*ptr_freq_data_target.offset(i)).szName.0 as *const i8);
+            let str_slice: &str = sz_name_cstr.to_str().unwrap();
+            if str_slice.contains("Total") {
+                i = i + 1;
+                continue;
+            }
+
+            usage.push(f64::floor(
+                (*ptr_util_data_target.offset(i)).FmtValue.Anonymous.doubleValue) as u16);
+            freq.push(f64::floor(
+                (*ptr_freq_data_target.offset(i)).FmtValue.Anonymous.doubleValue *
+                     ((*ptr_perf_data_target.offset(i)).FmtValue.Anonymous.doubleValue / 100.0)) as u16);
+
+            i = i + 1;
+        }
+    }
+
     Ok(CPUStats { usage, freq })
   }
 }

--- a/src/data_collector/cpu.rs
+++ b/src/data_collector/cpu.rs
@@ -115,13 +115,13 @@ impl DataCollector {
       }
 
       // The windows-rs crate does a little trolling and fails to generate an array of
-      // counter value item structs below whose size match the output the above calls
+      // counter value item structs whose size matches the output the above calls
       // are given. This could be due to mismatch in how the rust struct implementation
       // is handled vs what the C struct is like. It could be a byte alignment issue.
       // We simply do not know.
       //
       // However, this method *does* continue to work given some padding to avoid
-      // some padding to avoid buffer overruns. So double the size of our allocation to capture
+      // buffer overruns. So double the size of our allocation to capture
       // this problem and then proceed not to worry about it for the foreseeable future.
       let mut proc_freq_data: Vec<PDH_FMT_COUNTERVALUE_ITEM_A> =
           vec!(PDH_FMT_COUNTERVALUE_ITEM_A::default(); (proc_freq_cnt * 2) as usize);

--- a/src/data_collector/cpu.rs
+++ b/src/data_collector/cpu.rs
@@ -1,6 +1,3 @@
-use std::ffi::CStr;
-use std::mem;
-use std::process::exit;
 #[cfg(target_family = "unix")]
 use sysinfo::{ProcessorExt, SystemExt};
 
@@ -13,7 +10,18 @@ use windows::Win32::System::Performance::*;
 
 #[cfg(target_family = "windows")]
 use std::ptr;
+
+#[cfg(target_family = "windows")]
 use windows::Win32::Foundation::ERROR_SUCCESS;
+
+#[cfg(target_family = "windows")]
+use std::ffi::CStr;
+
+#[cfg(target_family = "windows")]
+use std::mem;
+
+#[cfg(target_family = "windows")]
+use std::process::exit;
 
 use super::DataCollector;
 
@@ -113,16 +121,16 @@ impl DataCollector {
       // We simply do not know.
       //
       // However, this method *does* continue to work given some padding to avoid
-      // some padding to avoid buffer overruns. So we add some slush here to capture
+      // some padding to avoid buffer overruns. So double the size of our allocation to capture
       // this problem and then proceed not to worry about it for the foreseeable future.
       let mut proc_freq_data: Vec<PDH_FMT_COUNTERVALUE_ITEM_A> =
-          vec!(PDH_FMT_COUNTERVALUE_ITEM_A::default(); (proc_freq_cnt + 2) as usize);
+          vec!(PDH_FMT_COUNTERVALUE_ITEM_A::default(); (proc_freq_cnt * 2) as usize);
 
       let mut proc_perf_data: Vec<PDH_FMT_COUNTERVALUE_ITEM_A> =
-          vec!(PDH_FMT_COUNTERVALUE_ITEM_A::default(); (proc_perf_cnt  + 2) as usize);
+          vec!(PDH_FMT_COUNTERVALUE_ITEM_A::default(); (proc_perf_cnt * 2) as usize);
 
       let mut proc_util_data: Vec<PDH_FMT_COUNTERVALUE_ITEM_A> =
-          vec!(PDH_FMT_COUNTERVALUE_ITEM_A::default(); (proc_util_cnt + 2) as usize);
+          vec!(PDH_FMT_COUNTERVALUE_ITEM_A::default(); (proc_util_cnt * 2) as usize);
 
       // Now when we invoke these methods again they should always return ERROR_SUCCESS.
       let ret = PdhGetFormattedCounterArrayA(self.pdh_proc_freq_counter,

--- a/src/data_collector/cpu.rs
+++ b/src/data_collector/cpu.rs
@@ -1,9 +1,15 @@
-use crate::types::CPUStats;
-use anyhow::Result;
+#[cfg(target_family = "unix")]
 use sysinfo::{ProcessorExt, SystemExt};
+
+use crate::types::CPUStats;
+
+use anyhow::Result;
+
+
 
 use super::DataCollector;
 
+#[cfg(target_family = "unix")]
 impl DataCollector {
   /// Gets the current CPU stats
   /// wait what the fuck this is an array of cores? 🥴👍
@@ -17,6 +23,16 @@ impl DataCollector {
 
     self.fetcher.refresh_cpu();
 
+    Ok(CPUStats { usage, freq })
+  }
+}
+
+#[cfg(target_family = "windows")]
+impl DataCollector {
+  pub fn get_cpu(&mut self) -> Result<CPUStats> {
+    let (mut usage, mut freq) = (vec![], vec![]);
+    // TODO: Implement use of perfmon querying.
+    //       We need to figure out where to store perfmon structures.
     Ok(CPUStats { usage, freq })
   }
 }

--- a/src/data_collector/mod.rs
+++ b/src/data_collector/mod.rs
@@ -11,7 +11,6 @@ use crate::types::{DynamicData, StaticData};
 use anyhow::{anyhow, Result};
 use nvml::NVML;
 use std::{collections::HashMap, time::SystemTime};
-use std::process::exit;
 use sysinfo::{ProcessRefreshKind, ProcessorExt, System, SystemExt};
 use thiserror::Error;
 
@@ -31,6 +30,9 @@ use windows::core::PCSTR;
 
 #[cfg(target_family = "windows")]
 use windows::Win32::Foundation::ERROR_SUCCESS;
+
+#[cfg(target_family = "windows")]
+use std::process::exit;
 
 #[derive(Error, Debug)]
 pub enum DataCollectorError {

--- a/src/data_collector/mod.rs
+++ b/src/data_collector/mod.rs
@@ -219,7 +219,10 @@ impl DataCollector {
     #[cfg(target_family = "windows")]
     unsafe {
       let ret = PdhCollectQueryData(self.pdh_query);
-      assert_eq!(ret, ERROR_SUCCESS.0 as i32);
+      if ret != ERROR_SUCCESS.0 as i32 {
+        eprintln!("Unable to query latest CPU information from perfmon.");
+        exit(1);
+      }
     }
 
     Ok(DynamicData {


### PR DESCRIPTION
On Windows, the sysinfo crate only reports base frequency for the system. It is unable to report realtime frequency of the CPU like on *nix platforms, and so even if your CPU is changing frequency in realtime or maybe even fixed at a boosted clock due to overclocking, it is not reflected in the Xornet UI.

This implements capture of that information and usage information through perfmon (e.g. the win32 pdh library), while allowing the existing sysinfo implementation to remain on *nix type operating systems. Blusk suggested just allowing the compiler to pick implementations at compile time, so rather than creating an abstraction over everything including sysinfo I just added code that gets picked up on Windows alone. That also includes importing the windows-rs crate.

I've tested this on Windows and also from WSL/Ubuntu and build and runtime continues to work as it had. Most of the interactions with perfmon are in "unsafe" code blocks, and while I added appropriate error checking, as I don't usually work in Rust but rather C, I'd appreciate any suggestions you may have to make it either cleaner, or just less verbose, if possible.